### PR TITLE
chore: maintain NPM package config and update GitHub Pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: lts/*
 
       - name: Install dependencies
-        run: npm ci --prefer-offline --no-audit
+        run: npm ci --prefer-offline --no-audit --ignore-scripts
 
       - name: Build documentation
         run: npm run build:docs

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
         "undici-types": "~6.3.0"
     },
     "publishConfig": {
-        "access": "restricted"
+        "access": "public"
     },
     "dependencies": {
         "@ceeblue/web-utils": "^7.0.1",


### PR DESCRIPTION
## Changes

- **Make package public again on npm**: Changed `publishConfig.access` from `"restricted"` to `"public"` in `package.json` to allow public installation of the package.

- **Fix GitHub Pages deployment**: Added `--ignore-scripts` flag to the `npm ci` command in the docs deployment workflow to prevent git hooks from being installed during CI. This resolves the deployment failure caused by commitlint rejecting the automated commit messages generated by the GitHub Pages deploy action.