### PR TITLE
Fix issues with PlayReady on Edge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <p align="center">
  <a href="#requirements">Requirements</a> •
  <a href="#usage">Usage</a> •
+ <a href="#drm">DRM</a> •
  <a href="#examples">Examples</a> •
  <a href="#building-locally">Building locally</a> •
  <a href="#logs">Logs</a> •
@@ -95,6 +96,63 @@ player.start({
 >   endPoint: <endPoint>
 >});
 >```
+
+
+## DRM
+
+WebRTS plays DRM-protected streams via [EME (Encrypted Media Extensions)](https://www.w3.org/TR/encrypted-media/). The supported key systems are:
+
+- **Widevine** (`com.widevine.alpha`) — Chrome, Firefox, Edge, Opera, Android.
+- **PlayReady** (`com.microsoft.playready`) — Edge, Xbox, Windows Store apps, many smart TVs (Samsung Tizen, LG webOS).
+- **FairPlay** (`com.apple.fps.1_0`) — Safari (macOS, iOS, iPadOS).
+
+Pass a `contentProtection` map to `player.start()` keyed by key system. The minimal form is a license URL string; FairPlay also needs a certificate URL:
+
+```javascript
+player.start({
+   endPoint: 'https://<hostname>/wrts/out+12423351-d0a2-4f0f-98a0-015b73f934f2/index.json',
+   contentProtection: {
+      'com.widevine.alpha': 'https://widevine.example.com/license',
+      'com.microsoft.playready': 'https://playready.example.com/license',
+      'com.apple.fps.1_0': {
+         license: 'https://fairplay.example.com/license',
+         certificate: 'https://fairplay.example.com/certificate'
+      }
+   }
+});
+```
+
+At runtime the player negotiates the most-preferred key system supported by the current browser.
+
+> [!TIP]
+> The [MediaKeysEngine](./src/media/keys/MediaKeysEngine.ts) can also be used standalone (outside of `Player`), for example to drive EME from another player.
+
+### PlayReady on Edge — known limitations
+
+For browser playback, prefer **Widevine** where it is available. PlayReady is fully supported but the Edge / Chromium implementation has constraints that every browser player has to work around:
+
+- **Avoid increasing `<video>.playbackRate` during playback.** The default `Player` raises the rate above 1.0 to catch up to live, which produces audio artifacts and visible video lag with PlayReady. Override the default by handling `onBufferChange` and clamping the rate to ≤ 1.0. Below is an example only slowing playback down when the buffer runs low:
+
+```javascript
+import { BufferState } from '@ceeblue/wrts-client';
+
+player.onBufferChange = () => {
+    let playbackRate = videoElement.playbackRate;
+    if (player.bufferState === BufferState.LOW) {
+        // Decrease playback rate linearly between [0.92, 0.84] as the buffer drops
+        const ratio =
+            Math.max(0, player.bufferLimitMiddle - player.bufferAmount) /
+            Math.max(1, 2 * (player.bufferLimitMiddle - player.bufferLimitLow));
+        playbackRate = Math.min(Math.round(92 + 8 * Math.min(ratio, 1)) / 100, playbackRate);
+    } else {
+        playbackRate = 1;
+    }
+    if (playbackRate !== videoElement.playbackRate) {
+        videoElement.playbackRate = playbackRate;
+    }
+};
+```
+- **Larger playback buffers work better.** PlayReady's decoder path needs more headroom; configuring buffer thresholds to roughly `min=400ms / max=2000ms` (instead of the WebRTS low-latency defaults) avoids stutter under bandwidth jitter.
 
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -134,22 +134,10 @@ For browser playback, prefer **Widevine** where it is available. PlayReady is fu
 - **Avoid increasing `<video>.playbackRate` during playback.** The default `Player` raises the rate above 1.0 to catch up to live, which produces audio artifacts and visible video lag with PlayReady. Override the default by handling `onBufferChange` and clamping the rate to ≤ 1.0. Below is an example only slowing playback down when the buffer runs low:
 
 ```javascript
-import { BufferState } from '@ceeblue/wrts-client';
-
 player.onBufferChange = () => {
-    let playbackRate = videoElement.playbackRate;
-    if (player.bufferState === BufferState.LOW) {
-        // Decrease playback rate linearly between [0.92, 0.84] as the buffer drops
-        const ratio =
-            Math.max(0, player.bufferLimitMiddle - player.bufferAmount) /
-            Math.max(1, 2 * (player.bufferLimitMiddle - player.bufferLimitLow));
-        playbackRate = Math.min(Math.round(92 + 8 * Math.min(ratio, 1)) / 100, playbackRate);
-    } else {
-        playbackRate = 1;
-    }
-    if (playbackRate !== videoElement.playbackRate) {
-        videoElement.playbackRate = playbackRate;
-    }
+   // Disable playback rate increase to avoid audio artifacts and video lag with PlayReady on Edge
+   // Keep the ability to decrease playback rate between [0.84, 0.92] to reduce the risk of stall when the network condition worsen
+   player.adjustPlaybackRate(84, 100);
 };
 ```
 - **Larger playback buffers work better.** PlayReady's decoder path needs more headroom; configuring buffer thresholds to roughly `min=400ms / max=2000ms` (instead of the WebRTS low-latency defaults) avoids stutter under bandwidth jitter.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <p align="center">
  <a href="#requirements">Requirements</a> •
  <a href="#usage">Usage</a> •
+ <a href="#playback-rate-adaptation">Playback rate adaptation</a> •
  <a href="#drm">DRM</a> •
  <a href="#examples">Examples</a> •
  <a href="#building-locally">Building locally</a> •
@@ -98,6 +99,24 @@ player.start({
 >```
 
 
+## Playback rate adaptation
+
+To stay close to the live edge and protect against stalls when the network worsens, the default `Player` continuously adjusts `<video>.playbackRate` from the buffer state — speeding up slightly to catch back up to live (up to 1.16x) and slowing down when the buffer runs low (down to 0.84x). This is a deliberate compromise: we prioritise low latency and stall protection over perfectly smooth audio.
+
+On **iOS / Safari**, that compromise can be audible — rate changes there sometimes produce small audio glitches. The default is still to adapt, because for most applications the latency / stall benefits outweigh the cost. If smoother audio matters more for your use case, disable adaptation on iOS / Safari (detected via `ManagedMediaSource`):
+
+```javascript
+player.onBufferChange = () => {
+   if (window.ManagedMediaSource) {
+      return; // iOS / Safari — skip playbackRate adjustments
+   }
+   player.adjustPlaybackRate();
+};
+```
+
+To narrow the range on any platform, override `onBufferChange` and pass custom percentages to `player.adjustPlaybackRate(minRate, maxRate)` (default 84 / 116).
+
+
 ## DRM
 
 WebRTS plays DRM-protected streams via [EME (Encrypted Media Extensions)](https://www.w3.org/TR/encrypted-media/). The supported key systems are:
@@ -140,6 +159,7 @@ player.onBufferChange = () => {
    player.adjustPlaybackRate(84, 100);
 };
 ```
+
 - **Larger playback buffers work better.** PlayReady's decoder path needs more headroom; configuring buffer thresholds to roughly `min=400ms / max=2000ms` (instead of the WebRTS low-latency defaults) avoids stutter under bandwidth jitter.
 
 

--- a/examples/player.html
+++ b/examples/player.html
@@ -486,13 +486,15 @@
                         ['HW & SW', 'HW_SECURE_DECODE,SW_SECURE_DECODE'],
                         ['SW', 'SW_SECURE_DECODE'],
                         ['HW', 'HW_SECURE_DECODE'],
-                        ['All', '']
+                        ['All', 'HW_SECURE_ALL,HW_SECURE_DECODE,SW_SECURE_DECODE'],
+                        ['(empty)', '']
                     ]),
                     audioRobustnesses: new Map([
                         ['HW & SW', 'HW_SECURE_CRYPTO,SW_SECURE_CRYPTO'],
                         ['SW', 'SW_SECURE_CRYPTO'],
                         ['HW', 'HW_SECURE_CRYPTO'],
-                        ['All', '']
+                        ['All', 'HW_SECURE_ALL,HW_SECURE_CRYPTO,SW_SECURE_CRYPTO'],
+                        ['(empty)', '']
                     ]),
                     contentProtection: [
                         { id: 'widevine', label: 'Widevine', keySystem: 'com.widevine.alpha',

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -19,6 +19,10 @@ const BUFFER_LIMIT_LOW = 150; // ms
 const BUFFER_LIMIT_HIGH = 550; // ms
 const TIMEOUT = 14000; // at least superior to max gop duration (10s)
 const BUFFER_CHANGE_STEP = 50; // ms
+const MIN_INCREASE_PLAYBACK_RATE = 108; // 108 means min 8% increase of the playback rate when buffer is full
+const DEFAULT_MAX_INCREASE_PLAYBACK_RATE = 116; // 116 means max 16% increase of the playback rate when buffer is full
+const MIN_DECREASE_PLAYBACK_RATE = 92; // 92 means min 8% decrease of the playback rate when buffer is low
+const DEFAULT_MAX_DECREASE_PLAYBACK_RATE = 84; // 84 means max 16% decrease of the playback rate when buffer is low
 
 const root = typeof window !== 'undefined' ? window : global;
 
@@ -208,11 +212,12 @@ export class Player extends EventEmitter implements IPlaying, ICMCD {
      * @event
      */
     onBufferChange(): void {
-        if (!ManagedMediaSource) {
-            // iPhone/iOS/Safari doesn't implement a smooth dynamic playbackRate change: during live it creates sound noise
-            // So by default disable it for iPhone, let the user re-enable it if needed
-            this.adjustPlaybackRate();
-        }
+        // iPhone/iOS/Safari doesn't implement a smooth dynamic playbackRate acceleration: during live it creates sound noise
+        // So by default disable playbackRate increase for iPhone, let the user re-enable it if needed
+        this.adjustPlaybackRate(
+            DEFAULT_MAX_DECREASE_PLAYBACK_RATE,
+            ManagedMediaSource ? 100 : DEFAULT_MAX_INCREASE_PLAYBACK_RATE
+        );
     }
 
     /**
@@ -1079,27 +1084,48 @@ export class Player extends EventEmitter implements IPlaying, ICMCD {
 
     /**
      * Adjust playback rate according to buffer state to avoid buffer overrun or underrun
+     *
+     * The minimum increase playback rate is 108% (1.08x), you can disable decrease by setting minRate to 100 or more,
+     * and the maximum increase playback rate is 116% (1.16x), you can disable increase by setting maxRate to 100 or less.
+     *
+     * Disabling increase can be useful with hardware decoding issues but note that this affects the ability of the player to catch up the live point after a congestion.
+     * Be careful when disabling decrease because it can increase the risk of stall when the network condition worsen.
+     *
+     * Note: Intended to be called from {@link onBufferState}
+     *
+     * @param minRate minimum playback rate in percentage, default to 84 (0.84x)
+     * @param maxRate maximum playback rate in percentage, default to 116 (1.16x)
      */
-    private adjustPlaybackRate() {
-        const playbackRate = this._video.playbackRate;
+    adjustPlaybackRate(minRate = DEFAULT_MAX_DECREASE_PLAYBACK_RATE, maxRate = DEFAULT_MAX_INCREASE_PLAYBACK_RATE) {
+        let playbackRate = 1; // by default we want normal speed
         if (this.bufferState === BufferState.HIGH) {
-            // Increase playback rate linearly between [1.08,1.16], reaches the max when bufferAmount > bufferLimitHigh + (bufferLimitHigh - bufferLimitMiddle)
-            const ratio =
-                Math.max(0, this.bufferAmount - this.bufferLimitHigh) /
-                Math.max(1, 2 * (this.bufferLimitHigh - this.bufferLimitMiddle));
-            this._video.playbackRate = Math.max(this._video.playbackRate, Math.round(108 + 8 * Math.min(ratio, 1)) / 100);
+            if (maxRate > 100) {
+                // Increase playback rate linearly (by default between [1.08,1.16]),
+                // reaches the max when bufferAmount > bufferLimitHigh + (bufferLimitHigh - bufferLimitMiddle)
+                const ratio =
+                    Math.max(0, this.bufferAmount - this.bufferLimitHigh) /
+                    Math.max(1, 2 * (this.bufferLimitHigh - this.bufferLimitMiddle));
+                playbackRate = Math.max(
+                    this._video.playbackRate,
+                    Math.round(MIN_INCREASE_PLAYBACK_RATE + (maxRate - MIN_INCREASE_PLAYBACK_RATE) * Math.min(ratio, 1)) / 100
+                );
+            }
         } else if (this.bufferState === BufferState.LOW) {
-            // Decrease playback rate linearly between [0.92,0.84], reaches the min when bufferAmount < bufferLimitLow - (bufferLimitMiddle - bufferLimitLow),
-            // Note: this threshold can be negative and thus never reached
-            const ratio =
-                Math.max(0, this.bufferLimitMiddle - this.bufferAmount) /
-                Math.max(1, 2 * (this.bufferLimitMiddle - this.bufferLimitLow));
-            this._video.playbackRate = Math.min(Math.round(92 + 8 * Math.min(ratio, 1)) / 100, this._video.playbackRate);
-        } else {
-            // OK or NONE
-            this._video.playbackRate = 1;
+            if (minRate < 100) {
+                // Decrease playback rate linearly (by default between [0.92,0.84]),
+                // reaches the min when bufferAmount < bufferLimitLow - (bufferLimitMiddle - bufferLimitLow),
+                // Note: this threshold can be negative and thus never reached
+                const ratio =
+                    Math.max(0, this.bufferLimitMiddle - this.bufferAmount) /
+                    Math.max(1, 2 * (this.bufferLimitMiddle - this.bufferLimitLow));
+                playbackRate = Math.min(
+                    Math.round(MIN_DECREASE_PLAYBACK_RATE - (MIN_DECREASE_PLAYBACK_RATE - minRate) * Math.min(ratio, 1)) / 100,
+                    this._video.playbackRate
+                );
+            }
         }
         if (playbackRate !== this._video.playbackRate) {
+            this._video.playbackRate = playbackRate;
             this.log(`Adapt playback rate to ${this._video.playbackRate}`).info();
         }
     }

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -19,10 +19,12 @@ const BUFFER_LIMIT_LOW = 150; // ms
 const BUFFER_LIMIT_HIGH = 550; // ms
 const TIMEOUT = 14000; // at least superior to max gop duration (10s)
 const BUFFER_CHANGE_STEP = 50; // ms
-const MIN_INCREASE_PLAYBACK_RATE = 108; // 108 means min 8% increase of the playback rate when buffer is full
-const DEFAULT_MAX_INCREASE_PLAYBACK_RATE = 116; // 116 means max 16% increase of the playback rate when buffer is full
-const MIN_DECREASE_PLAYBACK_RATE = 92; // 92 means min 8% decrease of the playback rate when buffer is low
-const DEFAULT_MAX_DECREASE_PLAYBACK_RATE = 84; // 84 means max 16% decrease of the playback rate when buffer is low
+
+const PLAYBACK_RATE_MAX = 116; // Default maxRate, 116 means max 16% increase of the playback rate when buffer is full
+const PLAYBACK_RATE_MAX_FLOOR = 108; // Minimum possible value for maxRate, 108 means min 8% increase of the playback rate when buffer is full
+
+const PLAYBACK_RATE_MIN_CEIL = 92; // Maximum possible value for minRate 92 means min 8% decrease of the playback rate when buffer is low
+const PLAYBACK_RATE_MIN = 84; // Default minRate, 84 means max 16% decrease of the playback rate when buffer is low
 
 const root = typeof window !== 'undefined' ? window : global;
 
@@ -210,14 +212,13 @@ export class Player extends EventEmitter implements IPlaying, ICMCD {
     /**
      * Event fire when the buffer amount changes  by at least BUFFER_CHANGE_STEP ms
      * @event
+     *
+     * Note: on iPhone / iOS / Safari, playbackRate changes can produce audible glitches during live streaming.
+     * In that case you can override `onBufferChange` to disable playbackRate adaptation on iOS / Safari
+     * (detected via `ManagedMediaSource`).
      */
     onBufferChange(): void {
-        // iPhone/iOS/Safari doesn't implement a smooth dynamic playbackRate acceleration: during live it creates sound noise
-        // So by default disable playbackRate increase for iPhone, let the user re-enable it if needed
-        this.adjustPlaybackRate(
-            DEFAULT_MAX_DECREASE_PLAYBACK_RATE,
-            ManagedMediaSource ? 100 : DEFAULT_MAX_INCREASE_PLAYBACK_RATE
-        );
+        this.adjustPlaybackRate();
     }
 
     /**
@@ -1085,47 +1086,53 @@ export class Player extends EventEmitter implements IPlaying, ICMCD {
     /**
      * Adjust playback rate according to buffer state to avoid buffer overrun or underrun
      *
-     * The minimum increase playback rate is 108% (1.08x), you can disable decrease by setting minRate to 100 or more,
-     * and the maximum increase playback rate is 116% (1.16x), you can disable increase by setting maxRate to 100 or less.
+     * The minimum increase playback rate is 108% (1.08x), you can disable increase by setting maxRate to 100 or less,
+     * and the maximum decrease playback rate is 92% (0.92x), you can disable decrease by setting minRate to 100 or more.
      *
      * Disabling increase can be useful with hardware decoding issues but note that this affects the ability of the player to catch up the live point after a congestion.
      * Be careful when disabling decrease because it can increase the risk of stall when the network condition worsen.
      *
-     * Note: Intended to be called from {@link onBufferState}
+     * Note: Intended to be called from {@link onBufferChange}
      *
-     * @param minRate minimum playback rate in percentage, default to 84 (0.84x)
-     * @param maxRate maximum playback rate in percentage, default to 116 (1.16x)
+     * @param minRate minimum playback rate in percentage, default to 84 (0.84x), if more than 92 it will be forced to 92
+     * @param maxRate maximum playback rate in percentage, default to 116 (1.16x), if less than 108 it will be forced to 108
      */
-    adjustPlaybackRate(minRate = DEFAULT_MAX_DECREASE_PLAYBACK_RATE, maxRate = DEFAULT_MAX_INCREASE_PLAYBACK_RATE) {
-        let playbackRate = 1; // by default we want normal speed
-        if (this.bufferState === BufferState.HIGH) {
-            if (maxRate > 100) {
-                // Increase playback rate linearly (by default between [1.08,1.16]),
-                // reaches the max when bufferAmount > bufferLimitHigh + (bufferLimitHigh - bufferLimitMiddle)
-                const ratio =
-                    Math.max(0, this.bufferAmount - this.bufferLimitHigh) /
-                    Math.max(1, 2 * (this.bufferLimitHigh - this.bufferLimitMiddle));
-                playbackRate = Math.max(
-                    this._video.playbackRate,
-                    Math.round(MIN_INCREASE_PLAYBACK_RATE + (maxRate - MIN_INCREASE_PLAYBACK_RATE) * Math.min(ratio, 1)) / 100
-                );
+    adjustPlaybackRate(minRate = PLAYBACK_RATE_MIN, maxRate = PLAYBACK_RATE_MAX) {
+        // We save the playbackRate before to change it to be able to log only if there is a real change
+        // Indeed when assiging video.playbackRate sometimes the value is not really changed because the browser can decide to ignore it
+        const playbackRate = this._video.playbackRate;
+        if (this.bufferState === BufferState.HIGH && maxRate > 100) {
+            if (maxRate < PLAYBACK_RATE_MAX_FLOOR) {
+                // Force maxRate to respect the minimum threshold to avoid too small increase that can cause more harm than good
+                maxRate = PLAYBACK_RATE_MAX_FLOOR;
             }
-        } else if (this.bufferState === BufferState.LOW) {
-            if (minRate < 100) {
-                // Decrease playback rate linearly (by default between [0.92,0.84]),
-                // reaches the min when bufferAmount < bufferLimitLow - (bufferLimitMiddle - bufferLimitLow),
-                // Note: this threshold can be negative and thus never reached
-                const ratio =
-                    Math.max(0, this.bufferLimitMiddle - this.bufferAmount) /
-                    Math.max(1, 2 * (this.bufferLimitMiddle - this.bufferLimitLow));
-                playbackRate = Math.min(
-                    Math.round(MIN_DECREASE_PLAYBACK_RATE - (MIN_DECREASE_PLAYBACK_RATE - minRate) * Math.min(ratio, 1)) / 100,
-                    this._video.playbackRate
-                );
+            // Increase playback rate linearly (by default between [1.08,1.16]),
+            // reaches the max when bufferAmount > bufferLimitHigh + (bufferLimitHigh - bufferLimitMiddle)
+            const ratio =
+                Math.max(0, this.bufferAmount - this.bufferLimitHigh) /
+                Math.max(1, 2 * (this.bufferLimitHigh - this.bufferLimitMiddle));
+            this._video.playbackRate = Math.max(
+                this._video.playbackRate,
+                Math.round(PLAYBACK_RATE_MAX_FLOOR + (maxRate - PLAYBACK_RATE_MAX_FLOOR) * Math.min(ratio, 1)) / 100
+            );
+        } else if (this.bufferState === BufferState.LOW && minRate < 100) {
+            if (minRate > PLAYBACK_RATE_MIN_CEIL) {
+                // Force minRate to respect the maximum threshold to avoid too small decrease that can cause more harm than good
+                minRate = PLAYBACK_RATE_MIN_CEIL;
             }
+            // Decrease playback rate linearly (by default between [0.92,0.84]),
+            // reaches the min when bufferAmount < bufferLimitLow - (bufferLimitMiddle - bufferLimitLow)
+            const ratio =
+                Math.max(0, this.bufferLimitMiddle - this.bufferAmount) /
+                Math.max(1, 2 * (this.bufferLimitMiddle - this.bufferLimitLow));
+            this._video.playbackRate = Math.min(
+                Math.round(PLAYBACK_RATE_MIN_CEIL - (PLAYBACK_RATE_MIN_CEIL - minRate) * Math.min(ratio, 1)) / 100,
+                this._video.playbackRate
+            );
+        } else {
+            this._video.playbackRate = 1;
         }
         if (playbackRate !== this._video.playbackRate) {
-            this._video.playbackRate = playbackRate;
             this.log(`Adapt playback rate to ${this._video.playbackRate}`).info();
         }
     }

--- a/src/media/MediaBuffer.ts
+++ b/src/media/MediaBuffer.ts
@@ -165,7 +165,7 @@ export class MediaBuffer extends Loggable {
             // We call changeType only once because PlayReady on Edge does not support multiple call to changeType and will fail
             if (!this._codecString) {
                 const packet = this._mimeType + '; codecs="' + track.codecString + '"';
-                this.log(`Update track${this._trackId == null ? ' ' : ` from ${this._trackId} to `}${trackId} ${packet}`).info();
+                this.log(`Initiate track and codec to ${trackId} ${packet}`).info();
                 this._packets.push(packet);
             }
             this._trackId = trackId;

--- a/src/media/MediaBuffer.ts
+++ b/src/media/MediaBuffer.ts
@@ -162,9 +162,8 @@ export class MediaBuffer extends Loggable {
                 return;
             }
             // to call changeType, before cmafWriter.init!
-            // PlayReady (and some other EME stacks) reject SourceBuffer.changeType() with the same codecString
-            // only push a changeType packet when the codec actually changed
-            if (this._codecString !== track.codecString) {
+            // We call changeType only once because PlayReady on Edge does not support multiple call to changeType and will fail
+            if (!this._codecString) {
                 const packet = this._mimeType + '; codecs="' + track.codecString + '"';
                 this.log(`Update track${this._trackId == null ? ' ' : ` from ${this._trackId} to `}${trackId} ${packet}`).info();
                 this._packets.push(packet);


### PR DESCRIPTION
### 🐛 Bug Fixes

- *(MediaBuffer)* Call changeType only once for PlayReady on Edge

### 📚 Documentation

- *(README)* Add DRM section and PlayReady-on-Edge limitations

### ⚙️ Miscellaneous Tasks

- *(player.html)* Fix robustness "all" and add "empty"